### PR TITLE
Only configuration objects should able to call a ValidateConfiguration function. 

### DIFF
--- a/src/config/config.go
+++ b/src/config/config.go
@@ -42,20 +42,20 @@ func LoadConfig(filename string) (*Configuration, error) {
 }
 
 // checks if each value in the config file is valid input
-func ValidateConfiguration(config *Configuration) error {
+func (c *Configuration) ValidateConfiguration() error {
 
 	//convert all strings to lower case to ignore any capitalizations
-	fileInputL := strings.ToLower(config.FileInputOption)
+	fileInputL := strings.ToLower(c.FileInputOption)
 
 	//checks for valid input corresponding to choice of live vs static data analysis
 	if fileInputL == "live" {
 		//require at least 1 subscription
-		if len(config.Subscriptions) == 0 {
+		if len(c.Subscriptions) == 0 {
 			return errors.New("choosing live data input stream requires to input at least one subscription")
 		}
 	} else if fileInputL == "static" {
 		//require valid file path
-		_, err := os.Stat(config.StaticFile)
+		_, err := os.Stat(c.StaticFile)
 		if os.IsNotExist(err) {
 			return errors.New("Invalid pathway to static file: " + err.Error())
 		}
@@ -69,27 +69,27 @@ func ValidateConfiguration(config *Configuration) error {
 
 	//require mad parameter
 	//set mad param to default value if no val set in config
-	if config.MadParameters <= 0 || config.MadParameters > 1000 {
-		config.MadParameters = 10
+	if c.MadParameters <= 0 || c.MadParameters > 1000 {
+		c.MadParameters = 10
 		fmt.Println("No valid mad parameter given. The default mad parameter was set to 10")
 	}
 
 	//require maxBuckets
 	//set maxBuckets to default value if not set in config
-	if config.MaxBuckets <= 0 {
-		config.MaxBuckets = 20
+	if c.MaxBuckets <= 0 {
+		c.MaxBuckets = 20
 		fmt.Println("No valid maxBuckets value given. The default maxBuckets was set to 20")
 	}
 
 	//added to check if no window size was put in
-	if config.WindowSize <= 0 {
-		config.WindowSize = 360
+	if c.WindowSize <= 0 {
+		c.WindowSize = 360
 		fmt.Println("No valid window size given. The default window size was set to 360")
 	}
 
 	//check if maxBuckets * windowSize is not greater than 1k - could lead to messy graph
 	//if so, give a warning
-	if (config.MaxBuckets * config.WindowSize) >= 1000 {
+	if (c.MaxBuckets * c.WindowSize) >= 1000 {
 		//return error if input is neither live or static
 		return errors.New("WindowSize and/or maxBuckets too large - plot may crash")
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -45,7 +45,11 @@ func main() {
 	if err != nil {
 		log.Fatal("Error loading configuration:", err)
 	}
-	config.ValidateConfiguration(configStruct)
+
+	err = configStruct.ValidateConfiguration() 
+	if err != nil {
+		log.Fatal("Failed to validate configuration")
+	}
 
 	// WaitGroup for waiting on goroutines to finish
 	var wg sync.WaitGroup

--- a/src/main.go
+++ b/src/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	err = configStruct.ValidateConfiguration() 
 	if err != nil {
-		log.Fatal("Failed to validate configuration")
+		log.Fatalf("Failed to validate configuration: %v", err)
 	}
 
 	// WaitGroup for waiting on goroutines to finish

--- a/src/static_data/get_static_data.go
+++ b/src/static_data/get_static_data.go
@@ -27,7 +27,10 @@ func main() {
 	if err != nil {
 		log.Fatal("Error loading configuration:", err)
 	}
-	config.ValidateConfiguration(configStruct)
+	err = configStruct.ValidateConfiguration()
+	if err != nil {
+		log.Fatalf("Failed to validate config: %v", err)
+	}
 	mainUrl := configStruct.URLStaticData
 	fmt.Println(mainUrl)
 


### PR DESCRIPTION
To avoid any object calling the ValidateConfiguration function - the caller should be known. In this case the caller must be of type Configuration. In case there is any object in the future that also has a ValidateConfiguration function now we can be certain each object is calling its proper function. 